### PR TITLE
Fix co-first author markers for under-review manuscript in CV.tex

### DIFF
--- a/CV.tex
+++ b/CV.tex
@@ -103,6 +103,7 @@ I am currently a PhD student under supervision by \href{https://scholar.google.c
 
 \section*{MANUSCRIPTS UNDER REVIEW}
 \noindent \textbf{Chou, F.-C. B.,*} Chang, C.-Y. E.,* Lee, W.-T. W., Chang, J.-H., \& Chen, P.-H. A. (Under review). Friendship in Mind: Linking mental representations of friendships to well-being.\\[\itemspace]
+\noindent Hsiao, P.-Y. A.,+ \textbf{Chou, F.-C. B.,+} \& Chen, P.-H. A. (Under review). Intersubject variations in national identity ideology map onto variations in neural dynamics during geopolitical video viewing.\\[\itemspace]
 
 \vspace{\sectionspace}
 


### PR DESCRIPTION
### Motivation
- Ensure the newly added entry in the "MANUSCRIPTS UNDER REVIEW" section reflects the correct co-first authorship markers and preserves the CV's author formatting (bold for `Chou, F.-C. B.`).
- Attempt to produce an updated `CV.pdf` from `CV.tex` as requested so the user receives a compiled PDF alongside the source change.

### Description
- Replaced the co-first author markers for the under-review entry from `*` to `+` so both `Hsiao, P.-Y. A.` and `Chou, F.-C. B.` are marked as co-first authors while keeping `Chou, F.-C. B.` bolded in the line in `CV.tex`.
- The change was applied by updating the single LaTeX line in `CV.tex` under the `MANUSCRIPTS UNDER REVIEW` section.
- A small automated edit script was used to perform the substitution to avoid manual formatting errors.

### Testing
- Verified the change is present with `git diff -- CV.tex` and the check succeeded.
- Inspected the updated lines with `nl -ba CV.tex | sed -n '102,108p'` and the expected line appears in the file.
- Confirmed repository state with `git status --short` and the command succeeded.
- Ran the edit as a Python script to update the line and the script executed successfully.
- Attempted to compile with `lualatex CV.tex` and `lulatex CV.tex`, but both binaries are not available in this environment (`command not found`), so compilation failed.
- Attempted to install a LaTeX toolchain with `apt-get install` and to install `tectonic` via `cargo`, but both installs failed due to outbound network/proxy errors (HTTP 403), so producing `CV.pdf` was not possible here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699db523967c832fac18afbd19812bca)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line LaTeX content change to a CV entry; no code execution or behavioral impact beyond document rendering.
> 
> **Overview**
> Updates `CV.tex` by adding a new “Manuscripts Under Review” entry and marking `Hsiao, P.-Y. A.` and `Chou, F.-C. B.` as co-first authors using `+` while keeping `Chou, F.-C. B.` bolded.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fbfb03fd5e0c0fb89a5d61bf6efe7b3bfb239ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new manuscript entry documenting research on individual variations in neural dynamics during geopolitical video viewing to the manuscripts under review section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->